### PR TITLE
Flexible extension params: required/additional extensions

### DIFF
--- a/code/params.json
+++ b/code/params.json
@@ -8,139 +8,143 @@
         "radius_um": 100
     },
     "duplicate_threshold": 0.9,
-    "return_scaled": true,
-    "random_spikes": {
-        "max_spikes_per_unit": 500,
-        "method": "uniform",
-        "margin_size": null,
-        "seed": null
-    },
-    "noise_levels": {
-        "num_chunks_per_segment": 20,
-        "chunk_size": 10000,
-        "seed": null
-    },
-    "waveforms": {
-        "ms_before": 3.0,
-        "ms_after": 4.0,
-        "dtype": null
-    },
-    "templates": {},
-    "spike_amplitudes": {
-        "peak_sign": "neg"
-    },
-    "template_similarity": {
-        "method": "l1"
-    },
-    "correlograms": {
-        "window_ms": 50.0,
-        "bin_ms": 1.0
-    },
-    "isi_histograms": {
-        "window_ms": 100.0,
-        "bin_ms": 5.0
-    },
-    "unit_locations": {
-        "method": "monopolar_triangulation"
-    },
-    "spike_locations": {
-        "method": "grid_convolution"
-    },
-    "template_metrics": {
-        "upsampling_factor": 10,
-        "sparsity": null,
-        "include_multi_channel_metrics": true
-    },
-    "principal_components": {
-        "n_components": 5,
-        "mode": "by_channel_local",
-        "whiten": true
-    },
-    "quality_metrics_names": [
-        "num_spikes",
-        "firing_rate",
-        "presence_ratio",
-        "snr",
-        "isi_violation",
-        "rp_violation",
-        "sliding_rp_violation",
-        "amplitude_cutoff",
-        "amplitude_median",
-        "amplitude_cv",
-        "synchrony",
-        "firing_range",
-        "drift",
-        "isolation_distance",
-        "l_ratio",
-        "d_prime",
-        "nearest_neighbor",
-        "silhouette"
-    ],
-    "quality_metrics": {
-        "presence_ratio": {
-            "bin_duration_s": 60
+    "return_in_uV": true,
+    "extensions": {
+        "random_spikes": {
+            "max_spikes_per_unit": 500,
+            "method": "uniform",
+            "margin_size": null,
+            "seed": null
         },
-        "snr": {
-            "peak_sign": "neg", 
-            "peak_mode": "extremum"
+        "noise_levels": {
+            "num_chunks_per_segment": 20,
+            "chunk_size": 10000,
+            "seed": null
         },
-        "isi_violation": {
-            "isi_threshold_ms": 1.5, 
-            "min_isi_ms": 0
+        "waveforms": {
+            "ms_before": 3.0,
+            "ms_after": 4.0,
+            "dtype": null
         },
-        "rp_violation": {
-            "refractory_period_ms": 1, 
-            "censored_period_ms": 0.0
-        },
-        "sliding_rp_violation": {
-            "bin_size_ms": 0.25,
-            "window_size_s": 1,
-            "exclude_ref_period_below_ms": 0.5,
-            "max_ref_period_ms": 10,
-            "contamination_values": null
-        },
-        "amplitude_cutoff": {
-            "peak_sign": "neg",
-            "num_histogram_bins": 100,
-            "histogram_smoothing_value": 3,
-            "amplitudes_bins_min_ratio": 5
-        },
-        "amplitude_median": {
+        "templates": {},
+        "spike_amplitudes": {
             "peak_sign": "neg"
         },
-        "amplitude_cv": {
-            "average_num_spikes_per_bin": 50,
-            "percentiles": [5, 95],
-            "min_num_bins": 10,
-            "amplitude_extension": "spike_amplitudes"
+        "template_similarity": {
+            "method": "l1"
         },
-        "firing_range": {
-            "bin_size_s": 5, 
-            "percentiles": [5, 95]
+        "correlograms": {
+            "window_ms": 50.0,
+            "bin_ms": 1.0
         },
-        "synchrony": {
-            "synchrony_sizes": [2, 4, 8]
+        "isi_histograms": {
+            "window_ms": 100.0,
+            "bin_ms": 5.0
         },
-        "nearest_neighbor": {
-            "max_spikes": 10000, 
-            "n_neighbors": 4
+        "unit_locations": {
+            "method": "monopolar_triangulation"
         },
-        "nn_isolation": {
-            "max_spikes": 10000, 
-            "min_spikes": 10, 
-            "n_neighbors": 4, 
-            "n_components": 10, 
-            "radius_um": 100
+        "spike_locations": {
+            "method": "grid_convolution"
         },
-        "nn_noise_overlap": {
-            "max_spikes": 10000, 
-            "min_spikes": 10, 
-            "n_neighbors": 4, 
-            "n_components": 10, 
-            "radius_um": 100
+        "template_metrics": {
+            "upsampling_factor": 10,
+            "sparsity": null,
+            "include_multi_channel_metrics": true
         },
-        "silhouette": {
-            "method": ["simplified"]
+        "principal_components": {
+            "n_components": 5,
+            "mode": "by_channel_local",
+            "whiten": true
+        },
+        "quality_metrics": {
+            "metric_names": [
+                "num_spikes",
+                "firing_rate",
+                "presence_ratio",
+                "snr",
+                "isi_violation",
+                "rp_violation",
+                "sliding_rp_violation",
+                "amplitude_cutoff",
+                "amplitude_median",
+                "amplitude_cv",
+                "synchrony",
+                "firing_range",
+                "drift",
+                "isolation_distance",
+                "l_ratio",
+                "d_prime",
+                "nearest_neighbor",
+                "silhouette"
+            ],
+            "metric_params": {
+                "presence_ratio": {
+                    "bin_duration_s": 60
+                },
+                "snr": {
+                    "peak_sign": "neg",
+                    "peak_mode": "extremum"
+                },
+                "isi_violation": {
+                    "isi_threshold_ms": 1.5,
+                    "min_isi_ms": 0
+                },
+                "rp_violation": {
+                    "refractory_period_ms": 1,
+                    "censored_period_ms": 0.0
+                },
+                "sliding_rp_violation": {
+                    "bin_size_ms": 0.25,
+                    "window_size_s": 1,
+                    "exclude_ref_period_below_ms": 0.5,
+                    "max_ref_period_ms": 10,
+                    "contamination_values": null
+                },
+                "amplitude_cutoff": {
+                    "peak_sign": "neg",
+                    "num_histogram_bins": 100,
+                    "histogram_smoothing_value": 3,
+                    "amplitudes_bins_min_ratio": 5
+                },
+                "amplitude_median": {
+                    "peak_sign": "neg"
+                },
+                "amplitude_cv": {
+                    "average_num_spikes_per_bin": 50,
+                    "percentiles": [5,95],
+                    "min_num_bins": 10,
+                    "amplitude_extension": "spike_amplitudes"
+                },
+                "firing_range": {
+                    "bin_size_s": 5,
+                    "percentiles": [5,95]
+                },
+                "synchrony": {
+                    "synchrony_sizes": [2,4,8]
+                },
+                "nearest_neighbor": {
+                    "max_spikes": 10000,
+                    "n_neighbors": 4
+                },
+                "nn_isolation": {
+                    "max_spikes": 10000,
+                    "min_spikes": 10,
+                    "n_neighbors": 4,
+                    "n_components": 10,
+                    "radius_um": 100
+                },
+                "nn_noise_overlap": {
+                    "max_spikes": 10000,
+                    "min_spikes": 10,
+                    "n_neighbors": 4,
+                    "n_components": 10,
+                    "radius_um": 100
+                },
+                "silhouette": {
+                    "method": ["simplified"]
+                }
+            }
         }
     }
 }

--- a/code/params.json
+++ b/code/params.json
@@ -9,19 +9,13 @@
     },
     "duplicate_threshold": 0.9,
     "return_in_uV": true,
-    "required_extensions": {
+    "extensions": {
         "random_spikes": {
             "max_spikes_per_unit": 500,
             "method": "uniform",
             "margin_size": null,
             "seed": null
         },
-        "templates": {
-            "ms_before": 2.0,
-            "ms_after": 3.0
-        }
-    },
-    "additional_extensions": {
         "noise_levels": {
             "num_chunks_per_segment": 20,
             "chunk_size": 10000,

--- a/code/params.json
+++ b/code/params.json
@@ -21,7 +21,7 @@
             "ms_after": 3.0
         }
     },
-    "extensions": {
+    "additional_extensions": {
         "noise_levels": {
             "num_chunks_per_segment": 20,
             "chunk_size": 10000,

--- a/code/params.json
+++ b/code/params.json
@@ -9,21 +9,27 @@
     },
     "duplicate_threshold": 0.9,
     "return_in_uV": true,
-    "extensions": {
+    "required_extensions": {
         "random_spikes": {
             "max_spikes_per_unit": 500,
             "method": "uniform",
             "margin_size": null,
             "seed": null
         },
+        "templates": {
+            "ms_before": 2.0,
+            "ms_after": 3.0
+        }
+    },
+    "extensions": {
         "noise_levels": {
             "num_chunks_per_segment": 20,
             "chunk_size": 10000,
             "seed": null
         },
         "waveforms": {
-            "ms_before": 3.0,
-            "ms_after": 4.0,
+            "ms_before": 2.0,
+            "ms_after": 3.0,
             "dtype": null
         },
         "templates": {},

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -278,7 +278,7 @@ if __name__ == "__main__":
         )
 
         # now postprocess
-        extension_dict = postprocessing_params.get("extension_dict")
+        extension_dict = postprocessing_params.get("extensions", {})
         required_extensions = ["random_spikes", "templates"]
         for req in required_extensions:
             if req not in extension_dict:

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -342,7 +342,7 @@ if __name__ == "__main__":
         quality_metrics_ext_params = extension_dict.pop("quality_metrics", None)
 
         if len(additional_extension_dict) > 0:
-            logging.info("\tComputing all postprocessing extensions")
+            logging.info(f"\tComputing postprocessing extensions: {list(extension_dict.keys())}")
             sorting_analyzer.compute(extension_dict)
 
         if quality_metrics_ext_params is not None:

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -280,16 +280,16 @@ if __name__ == "__main__":
         )
 
         # now postprocess
-        required_extension_dict = postprocessing_params.get("required_extensions")
+        extension_dict = postprocessing_params.get("extension_dict")
         required_extensions = ["random_spikes", "templates"]
         for req in required_extensions:
-            if req not in required_extension_dict:
+            if req not in extension_dict:
                 raise ValueError(
                     f"'{req}' extension is required postprocessing and downstream steps, but not found in parameters"
                 )
-
+        extensions_for_duplication = {ext: extension_dict[ext] for ext in required_extensions}
         if postprocessing_params.get("duplicate_threshold") is not None:
-            sorting_analyzer_full.compute(required_extension_dict)
+            sorting_analyzer_full.compute(extensions_for_duplication)
             sorting_deduplicated = sc.remove_redundant_units(
                 sorting_analyzer_full, duplicate_threshold=postprocessing_params["duplicate_threshold"]
             )
@@ -339,12 +339,11 @@ if __name__ == "__main__":
 
         # Now compute all extensions
         # quality metrics are computed separately at the end, for better logging and error handling
-        additional_extension_dict = postprocessing_params.get("additional_extensions", {})
-        quality_metrics_ext_params = additional_extension_dict.pop("quality_metrics", None)
+        quality_metrics_ext_params = extension_dict.pop("quality_metrics", None)
 
         if len(additional_extension_dict) > 0:
             logging.info("\tComputing all postprocessing extensions")
-            sorting_analyzer.compute(additional_extension_dict)
+            sorting_analyzer.compute(extension_dict)
 
         if quality_metrics_ext_params is not None:
             logging.info("\tComputing quality metrics")

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -56,7 +56,9 @@ use_motion_corrected_help = (
     "If True and motion corrected has been computed (and not applied), "
     "it applies motion interpolation to the recording prior to postprocessing."
 )
-use_motion_corrected_group.add_argument("static_use_motion_corrected", nargs="?", default="false", help=use_motion_corrected_help)
+use_motion_corrected_group.add_argument(
+    "static_use_motion_corrected", nargs="?", default="false", help=use_motion_corrected_help
+)
 use_motion_corrected_group.add_argument("--use-motion-corrected", action="store_true", help=use_motion_corrected_help)
 
 n_jobs_group = parser.add_mutually_exclusive_group()
@@ -67,7 +69,11 @@ n_jobs_help = (
 n_jobs_group.add_argument("static_n_jobs", nargs="?", default="-1", help=n_jobs_help)
 n_jobs_group.add_argument("--n-jobs", default="-1", help=n_jobs_help)
 
-parser.add_argument("--params", default=None, help="Path to the parameters file or JSON string. If given, it will override all other arguments.")
+parser.add_argument(
+    "--params",
+    default=None,
+    help="Path to the parameters file or JSON string. If given, it will override all other arguments.",
+)
 
 if __name__ == "__main__":
     args = parser.parse_args()
@@ -91,7 +97,6 @@ if __name__ == "__main__":
         with open("params.json", "r") as f:
             postprocessing_params = json.load(f)
         USE_MOTION_CORRECTED = args.use_motion_corrected or args.static_use_motion_corrected == "true"
-        
 
     # Use CO_CPUS/N_JOBS_EXT env variable if available
     N_JOBS_EXT = os.getenv("CO_CPUS") or os.getenv("N_JOBS_EXT")
@@ -229,9 +234,7 @@ if __name__ == "__main__":
                 recording_bin_f = spre.astype(recording_bin, "float32")
 
                 recording_bin = interpolate_motion(
-                    recording_bin_f,
-                    motion=motion_info["motion"],
-                    **interpolate_motion_kwargs
+                    recording_bin_f, motion=motion_info["motion"], **interpolate_motion_kwargs
                 )
                 # InterpolateMotion is not compatible with times.
                 # Removing time info for postprocessing
@@ -242,9 +245,7 @@ if __name__ == "__main__":
                 if recording_lazy is not None:
                     recording_lazy_f = spre.astype(recording_bin, "float32")
                     recording_lazy = interpolate_motion(
-                        recording_lazy_f,
-                        motion=motion_info["motion"],
-                        **interpolate_motion_kwargs
+                        recording_lazy_f, motion=motion_info["motion"], **interpolate_motion_kwargs
                     )
                     # InterpolateMotion is not compatible with times.
                     # Removing time info for postprocessing
@@ -269,33 +270,49 @@ if __name__ == "__main__":
             np.save(postprocessing_output_folder / "placeholder.npy", mock_array)
             continue
 
+        # First, we create a full sorting analyzer with the binary recording and all units,
+        # this is needed to compute sparsity and some extensions that are needed for de-duplication
+        # (e.g. random_spikes and templates)
         logging.info(f"\tCreating sorting analyzer")
+        return_in_uV = postprocessing_params.get("return_in_uV") or postprocessing_params.get("return_scaled")
         sorting_analyzer_full = si.create_sorting_analyzer(
-            sorting=sorting,
-            recording=recording_bin,
-            sparse=True,
-            return_scaled=postprocessing_params["return_scaled"],
-            **sparsity_params
+            sorting=sorting, recording=recording_bin, sparse=True, return_in_uV=return_in_uV, **sparsity_params
         )
-        # compute templates for de-duplication
-        # now postprocess
-        analyzer_dict = postprocessing_params.copy()
-        analyzer_dict.pop("duplicate_threshold")
-        analyzer_dict.pop("return_scaled")
-        sorting_analyzer_full.compute("random_spikes", **analyzer_dict["random_spikes"])
-        sorting_analyzer_full.compute("templates")
-        # de-duplication
-        sorting_deduplicated = sc.remove_redundant_units(
-            sorting_analyzer_full, duplicate_threshold=postprocessing_params["duplicate_threshold"]
-        )
-        logging.info(
-            f"\tNumber of original units: {len(sorting.unit_ids)} -- Number of units after de-duplication: {len(sorting_deduplicated.unit_ids)}"
-        )
-        n_duplicated = int(len(sorting.unit_ids) - len(sorting_deduplicated.unit_ids))
-        postprocessing_notes += f"\n- Removed {n_duplicated} duplicated units.\n"
-        deduplicated_unit_ids = sorting_deduplicated.unit_ids
 
-        sorting_analyzer_dedup = sorting_analyzer_full.select_units(sorting_deduplicated.unit_ids)
+        # now postprocess
+        extension_dict = postprocessing_params.get("extensions", {})
+
+        # Compute templates for de-duplication
+        # random_spikes and templates are needed for de-duplication,
+        # so we compute them first if they are in the extensions dict
+        if "random_spikes" in extension_dict and "templates" in extension_dict:
+            sorting_analyzer_full.compute("random_spikes", **analyzer_dict["random_spikes"])
+            sorting_analyzer_full.compute("templates")
+            sorting_deduplicated = sc.remove_redundant_units(
+                sorting_analyzer_full, duplicate_threshold=postprocessing_params["duplicate_threshold"]
+            )
+            logging.info(
+                f"\tNumber of original units: {len(sorting.unit_ids)} -- "
+                f"Number of units after de-duplication: {len(sorting_deduplicated.unit_ids)}"
+            )
+            n_duplicated = int(len(sorting.unit_ids) - len(sorting_deduplicated.unit_ids))
+            postprocessing_notes += f"\n- Removed {n_duplicated} duplicated units.\n"
+            deduplicated_unit_ids = sorting_deduplicated.unit_ids
+            deduplicated_unit_indices = sorting.ids_to_indices(deduplicated_unit_ids)
+
+            full_sparsity = sorting_analyzer_full.sparsity
+            sparsity = si.ChannelSparsity(
+                mask=full_sparsity.mask[deduplicated_unit_indices, :],
+                channel_ids=full_sparsity.channel_ids,
+                unit_ids=deduplicated_unit_ids,
+            )
+        else:
+            sorting_deduplicated = sorting
+            sparsity = sorting_analyzer_full.sparsity
+            logging.info(
+                f"\tDe-duplication skipped because 'random_spikes' and 'templates' extensions "
+                f"are required for de-duplication, but not found in extensions params."
+            )
 
         if recording_lazy is not None:
             recording = recording_lazy
@@ -304,7 +321,7 @@ if __name__ == "__main__":
             recording = recording_bin
             recording_tmp = None
 
-        # create a sorting analyzer in binary_folder in scratch
+        # Create a sorting analyzer in binary_folder in scratch
         # this prevents issues with shared memory sizes
         sorting_analyzer = si.create_sorting_analyzer(
             sorting=sorting_deduplicated,
@@ -312,35 +329,33 @@ if __name__ == "__main__":
             format="binary_folder",
             folder=scratch_folder / "tmp_analyzer",
             sparse=True,
-            return_scaled=postprocessing_params["return_scaled"],
-            sparsity=sorting_analyzer_dedup.sparsity
+            return_scaled=return_in_uV,
+            sparsity=sparsity,
         )
 
         if recording_tmp is not None:
             logging.info(f"\tSetting temporary binary recording")
             sorting_analyzer.set_temporary_recording(recording_tmp)
 
-        # now compute all extensions
-        logging.info("\tComputing all postprocessing extensions")
-        sorting_analyzer.compute(analyzer_dict)
-            
-        logging.info("\tComputing quality metrics")
-        qm = sorting_analyzer.compute(
-            "quality_metrics",
-            metric_names=quality_metrics_names,
-            qm_params=quality_metrics_params
-        )
+        # Now compute all extensions
+        # quality metrics are computed separately at the end, for better logging and error handling
+        quality_metrics_ext_params = extension_dict.pop("quality_metrics", None)
+
+        if len(extension_dict) > 0:
+            logging.info("\tComputing all postprocessing extensions")
+            sorting_analyzer.compute(extension_dict)
+
+        if quality_metrics_ext_params is not None:
+            logging.info("\tComputing quality metrics")
+            _ = sorting_analyzer.compute("quality_metrics", **quality_metrics_ext_params)
 
         # save as zarr and delete tmp_analyzer
         logging.info("\tSaving SortingAnalyzer to zarr")
-        sorting_analyzer = sorting_analyzer.save_as(
-            format="zarr",
-            folder=postprocessing_output_folder
-        )
+        sorting_analyzer = sorting_analyzer.save_as(format="zarr", folder=postprocessing_output_folder)
         try:
-           shutil.rmtree(scratch_folder / "tmp_analyzer")
+            shutil.rmtree(scratch_folder / "tmp_analyzer")
         except:
-           logging.info("Failed to delete temporary analyzer folder in scratch")
+            logging.info("Failed to delete temporary analyzer folder in scratch")
 
         t_postprocessing_end = time.perf_counter()
         elapsed_time_postprocessing = np.round(t_postprocessing_end - t_postprocessing_start, 2)
@@ -354,11 +369,7 @@ if __name__ == "__main__":
             stage=ProcessStage.PROCESSING,
             name="Ephys postprocessing",
             experimenters=["Alessio Buccino"],
-            code=Code(
-                url=URL,
-                version=VERSION, # either release or git commit
-                parameters=postprocessing_params
-            ),
+            code=Code(url=URL, version=VERSION, parameters=postprocessing_params),  # either release or git commit
             start_date_time=datetime_start_postprocessing,
             end_date_time=datetime_start_postprocessing + timedelta(seconds=np.floor(elapsed_time_postprocessing)),
             output_path=str(results_folder),

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -339,7 +339,7 @@ if __name__ == "__main__":
         # quality metrics are computed separately at the end, for better logging and error handling
         quality_metrics_ext_params = extension_dict.pop("quality_metrics", None)
 
-        if len(additional_extension_dict) > 0:
+        if len(extension_dict) > 0:
             logging.info(f"\tComputing postprocessing extensions: {list(extension_dict.keys())}")
             sorting_analyzer.compute(extension_dict)
 

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -280,14 +280,16 @@ if __name__ == "__main__":
         )
 
         # now postprocess
-        extension_dict = postprocessing_params.get("extensions", {})
+        required_extension_dict = postprocessing_params.get("required_extensions")
+        required_extensions = ["random_spikes", "templates"]
+        for req in required_extensions:
+            if req not in required_extension_dict:
+                raise ValueError(
+                    f"'{req}' extension is required postprocessing and downstream steps, but not found in parameters"
+                )
 
-        # Compute templates for de-duplication
-        # random_spikes and templates are needed for de-duplication,
-        # so we compute them first if they are in the extensions dict
-        if "random_spikes" in extension_dict and "templates" in extension_dict:
-            sorting_analyzer_full.compute("random_spikes", **analyzer_dict["random_spikes"])
-            sorting_analyzer_full.compute("templates")
+        if postprocessing_params.get("duplicate_threshold") is not None:
+            sorting_analyzer_full.compute(required_extension_dict)
             sorting_deduplicated = sc.remove_redundant_units(
                 sorting_analyzer_full, duplicate_threshold=postprocessing_params["duplicate_threshold"]
             )
@@ -307,12 +309,10 @@ if __name__ == "__main__":
                 unit_ids=deduplicated_unit_ids,
             )
         else:
+            logging.info(f"\tSkipping de-duplication")
             sorting_deduplicated = sorting
             sparsity = sorting_analyzer_full.sparsity
-            logging.info(
-                f"\tDe-duplication skipped because 'random_spikes' and 'templates' extensions "
-                f"are required for de-duplication, but not found in extensions params."
-            )
+            n_duplicated = 0
 
         if recording_lazy is not None:
             recording = recording_lazy
@@ -339,11 +339,12 @@ if __name__ == "__main__":
 
         # Now compute all extensions
         # quality metrics are computed separately at the end, for better logging and error handling
-        quality_metrics_ext_params = extension_dict.pop("quality_metrics", None)
+        additional_extension_dict = postprocessing_params.get("additional_extensions", {})
+        quality_metrics_ext_params = additional_extension_dict.pop("quality_metrics", None)
 
-        if len(extension_dict) > 0:
+        if len(additional_extension_dict) > 0:
             logging.info("\tComputing all postprocessing extensions")
-            sorting_analyzer.compute(extension_dict)
+            sorting_analyzer.compute(additional_extension_dict)
 
         if quality_metrics_ext_params is not None:
             logging.info("\tComputing quality metrics")

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -151,8 +151,6 @@ if __name__ == "__main__":
     si.set_global_job_kwargs(**job_kwargs)
 
     sparsity_params = postprocessing_params.pop("sparsity")
-    quality_metrics_names = postprocessing_params.pop("quality_metrics_names")
-    quality_metrics_params = postprocessing_params.pop("quality_metrics")
 
     ####### POSTPROCESSING ########
     logging.info("\nPOSTPROCESSING")


### PR DESCRIPTION
This PR modifies the definition of extensions in the params, from a flat dictionary to two new sections:
- required_extensions: including needed `random_spikes`/`templates` extensions
- additional_extensions: all other extensions


Also updated `return_scaled` to `return_in_uV` and simplified logic to extract sarsity after deduplication